### PR TITLE
better and configurable benchmarking

### DIFF
--- a/services/cache/cachemiss_test.go
+++ b/services/cache/cachemiss_test.go
@@ -30,7 +30,7 @@ type cachePad struct {
 }
 
 type padding struct {
-	_ [64]byte
+	_ [64]byte // intel core i7 cache line size is 64 bytes
 }
 
 func BenchmarkCacheTESTNoPad(b *testing.B) {

--- a/services/cache/cachemiss_test.go
+++ b/services/cache/cachemiss_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package cache_test
 
 import (

--- a/services/cache/cachemiss_test.go
+++ b/services/cache/cachemiss_test.go
@@ -1,0 +1,80 @@
+package cache_test
+
+import (
+	"sync"
+	"testing"
+)
+
+const M = 1000000
+
+type cacheMiss struct {
+	f1 uint32
+	f2 uint32
+}
+
+type cacheHit struct {
+	f1 uint64
+	f2 uint64
+}
+
+var out32 uint8
+var out64 uint64
+
+type cacheNoPad struct {
+	n int
+}
+
+type cachePad struct {
+	n int
+	_ padding
+}
+
+type padding struct {
+	_ [64]byte
+}
+
+func BenchmarkCacheTESTNoPad(b *testing.B) {
+	c1 := cacheNoPad{}
+	c2 := cacheNoPad{}
+	b.ResetTimer()
+	wg := sync.WaitGroup{}
+	for i := 0; i < b.N; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < M; j++ {
+				c1.n += j
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < M; j++ {
+				c2.n += j
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+func BenchmarkCacheTESTPad(b *testing.B) {
+	c1 := cachePad{}
+	c2 := cachePad{}
+	b.ResetTimer()
+	wg := sync.WaitGroup{}
+	for i := 0; i < b.N; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < M; j++ {
+				c1.n += j
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < M; j++ {
+				c2.n += j
+			}
+		}()
+		wg.Wait()
+	}
+}

--- a/services/cache/lru.go
+++ b/services/cache/lru.go
@@ -24,21 +24,23 @@ type LRU struct {
 	size                   int
 	evictList              *list.List
 	items                  map[string]*list.Element
-	lock                   sync.RWMutex
+	lock                   paddedlock
 	defaultExpiry          time.Duration
 	invalidateClusterEvent string
 	currentGeneration      int64
 	len                    int
 	encoder                Encoder
-	_                      [8]byte
+	_                      [80]byte
 }
 
 func (L *LRU) lock_() {
-	L.lock.Lock()
+	//L.lock.Lock()
+	L.lock.lock.Lock()
 }
 
 func (L *LRU) unlock() {
-	L.lock.Unlock()
+	//L.lock.Unlock()
+	L.lock.lock.Unlock()
 }
 
 // LRUOptions contains options for initializing LRU cache

--- a/services/cache/lru.go
+++ b/services/cache/lru.go
@@ -9,6 +9,15 @@ import (
 	"time"
 )
 
+type padding struct {
+	_ [64 - 8]byte
+}
+
+type paddedlock struct {
+	lock sync.RWMutex
+	_    padding
+}
+
 // LRU is a thread-safe fixed size LRU cache.
 type LRU struct {
 	name                   string
@@ -21,6 +30,15 @@ type LRU struct {
 	currentGeneration      int64
 	len                    int
 	encoder                Encoder
+	_                      [8]byte
+}
+
+func (L *LRU) lock_() {
+	L.lock.Lock()
+}
+
+func (L *LRU) unlock() {
+	L.lock.Unlock()
 }
 
 // LRUOptions contains options for initializing LRU cache
@@ -59,8 +77,8 @@ func NewLRU(opts *LRUOptions) Cache {
 
 // Purge is used to completely clear the cache.
 func (l *LRU) Purge() error {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+	l.lock_()
+	defer l.unlock()
 
 	l.len = 0
 	l.currentGeneration++
@@ -82,23 +100,23 @@ func (l *LRU) SetWithDefaultExpiry(key string, value interface{}) error {
 // SetWithExpiry adds the given key and value to the cache with the given expiry. If the key
 // already exists, it will overwrite the previoous value
 func (l *LRU) SetWithExpiry(key string, value interface{}, ttl time.Duration) error {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+	l.lock_()
+	defer l.unlock()
 	return l.set(key, value, ttl)
 }
 
 // Get the content stored in the cache for the given key, and decode it into the value interface.
 // return ErrKeyNotFound if the key is missing from the cache
 func (l *LRU) Get(key string, value interface{}) error {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+	l.lock_()
+	defer l.unlock()
 	return l.get(key, value)
 }
 
 // Remove deletes the value for a key.
 func (l *LRU) Remove(key string) error {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+	l.lock_()
+	defer l.unlock()
 
 	if ent, ok := l.items[key]; ok {
 		l.removeElement(ent)
@@ -108,8 +126,8 @@ func (l *LRU) Remove(key string) error {
 
 // Keys returns a slice of the keys in the cache.
 func (l *LRU) Keys() ([]string, error) {
-	l.lock.RLock()
-	defer l.lock.RUnlock()
+	l.lock_()
+	defer l.unlock()
 
 	keys := make([]string, l.len)
 	i := 0
@@ -125,8 +143,8 @@ func (l *LRU) Keys() ([]string, error) {
 
 // Len returns the number of items in the cache.
 func (l *LRU) Len() (int, error) {
-	l.lock.RLock()
-	defer l.lock.RUnlock()
+	l.lock_()
+	defer l.unlock()
 	return l.len, nil
 }
 

--- a/services/cache/lru_striped.go
+++ b/services/cache/lru_striped.go
@@ -7,6 +7,8 @@ import (
 	"hash/maphash"
 	"runtime"
 	"time"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 type LRUStriped struct {
@@ -31,12 +33,15 @@ func (L *LRUStriped) SetWithDefaultExpiry(key string, value interface{}) error {
 }
 
 func (L *LRUStriped) hashkeyMapHash(key string) uint64 {
-	h := &maphash.Hash{}
-	h.SetSeed(L.seed)
-	if _, err := h.WriteString(key); err != nil {
-		panic(err)
-	}
-	return h.Sum64()
+	/*
+		h := &maphash.Hash{}
+		h.SetSeed(L.seed)
+		if _, err := h.WriteString(key); err != nil {
+			panic(err)
+		}
+		return h.Sum64()
+	*/
+	return xxhash.Sum64String(key)
 }
 
 func (L *LRUStriped) keyBucket(key string) *LRU {

--- a/services/cache/lru_striped_test.go
+++ b/services/cache/lru_striped_test.go
@@ -196,13 +196,13 @@ func staticParams() []benchCase {
 		Size:           128,
 		WriteRoutines:  2,
 		WritePause:     time.Millisecond * 5,
-		AccessFraction: 1,
+		AccessFraction: 4,
 		MakeLRU:        cacheMakeAndName{Name: "lru", Make: NewLRU},
 		Buckets:        1,
 		Encoder:        NilEncoder{},
 	}
 	striped := lru
-	striped.Buckets = 2
+	striped.Buckets = 4
 	striped.MakeLRU = cacheMakeAndName{Name: "str", Make: NewLRUStriped}
 	return []benchCase{lru, striped}
 }

--- a/services/cache/lru_striped_test.go
+++ b/services/cache/lru_striped_test.go
@@ -165,7 +165,7 @@ func generateLRU_Concurrent_Cases(params parameters) []benchCase {
 	return benchCases
 }
 
-func BenchmarkLRU_Concurrent(b *testing.B) {
+func automaticParams() []benchCase {
 	paramsStriped := parameters{
 		Size:           []int{512, 10000},
 		WriteRoutines:  []int{1, runtime.NumCPU() / 2, runtime.NumCPU() - 1, runtime.NumCPU()},
@@ -186,6 +186,33 @@ func BenchmarkLRU_Concurrent(b *testing.B) {
 	benchCases := generateLRU_Concurrent_Cases(paramsLRU)
 	benchCases = append(benchCases, generateLRU_Concurrent_Cases(paramsStriped)...)
 
+	return benchCases
+}
+
+func staticParams() []benchCase {
+	return []benchCase{
+		{
+			Size:           128,
+			WriteRoutines:  2,
+			WritePause:     time.Millisecond * 5,
+			AccessFraction: 1,
+			MakeLRU:        cacheMakeAndName{Name: "lru", Make: NewLRU},
+			Buckets:        1,
+		},
+		{
+			Size:           128,
+			WriteRoutines:  2,
+			WritePause:     time.Millisecond * 5,
+			AccessFraction: 1,
+			MakeLRU:        cacheMakeAndName{Name: "str", Make: NewLRUStriped},
+			Buckets:        4,
+		},
+	}
+}
+
+func BenchmarkLRU_Concurrent(b *testing.B) {
+	benchCases := automaticParams()
+	benchCases = staticParams()
 	for _, benchCase := range benchCases {
 		name := fmt.Sprintf("%s_buckets-%d_af-%d_wp-%v_wr-%d_size-%d",
 			benchCase.MakeLRU.Name,

--- a/services/cache/lru_striped_test.go
+++ b/services/cache/lru_striped_test.go
@@ -194,7 +194,7 @@ func automaticParams() []benchCase {
 func staticParams() []benchCase {
 	lru := benchCase{
 		Size:           128,
-		WriteRoutines:  1,
+		WriteRoutines:  2,
 		WritePause:     time.Millisecond * 5,
 		AccessFraction: 1,
 		MakeLRU:        cacheMakeAndName{Name: "lru", Make: NewLRU},
@@ -202,7 +202,7 @@ func staticParams() []benchCase {
 		Encoder:        NilEncoder{},
 	}
 	striped := lru
-	striped.Buckets = 1
+	striped.Buckets = 2
 	striped.MakeLRU = cacheMakeAndName{Name: "str", Make: NewLRUStriped}
 	return []benchCase{lru, striped}
 }

--- a/services/cache/lru_striped_test.go
+++ b/services/cache/lru_striped_test.go
@@ -101,6 +101,7 @@ func TestLRUStuff(t *testing.T) {
 	log.Println(unsafe.Sizeof(LRU{}))
 	log.Println(unsafe.Sizeof(&LRU{}))
 	log.Println(unsafe.Sizeof(wraplru{}))
+	log.Println(unsafe.Sizeof(LRUStriped{}))
 }
 
 var sum uint64


### PR DESCRIPTION
4-vCPU KVM:

```
florent@lplp:~/repos/mattermost-server/services/cache$ go test -test.bench "^BenchmarkLRU_Concurrent" -test.run ^$ -test.timeout 10h
goos: linux
goarch: amd64
pkg: github.com/mattermost/mattermost-server/v5/services/cache
BenchmarkLRU_Concurrent/lru_buckets-2_af-4_wr-1_size-128-4               6683554               193 ns/op
BenchmarkLRU_Concurrent/lru_buckets-2_af-4_wr-2_size-128-4               1000000              1084 ns/op
BenchmarkLRU_Concurrent/lru_buckets-2_af-4_wr-3_size-128-4                878160              1497 ns/op
BenchmarkLRU_Concurrent/lru_buckets-2_af-4_wr-4_size-128-4               1000000              2041 ns/op
BenchmarkLRU_Concurrent/str_buckets-1_af-4_wr-1_size-128-4               4789778               260 ns/op
BenchmarkLRU_Concurrent/str_buckets-2_af-4_wr-1_size-128-4               4048780               317 ns/op
BenchmarkLRU_Concurrent/str_buckets-3_af-4_wr-1_size-128-4               4105341               275 ns/op
BenchmarkLRU_Concurrent/str_buckets-4_af-4_wr-1_size-128-4               2416659               453 ns/op
BenchmarkLRU_Concurrent/str_buckets-1_af-4_wr-2_size-128-4               1000000              1063 ns/op
BenchmarkLRU_Concurrent/str_buckets-2_af-4_wr-2_size-128-4               1999072               750 ns/op
BenchmarkLRU_Concurrent/str_buckets-3_af-4_wr-2_size-128-4               1929896               595 ns/op
BenchmarkLRU_Concurrent/str_buckets-4_af-4_wr-2_size-128-4               1568766               775 ns/op
BenchmarkLRU_Concurrent/str_buckets-1_af-4_wr-3_size-128-4                769189              1604 ns/op
BenchmarkLRU_Concurrent/str_buckets-2_af-4_wr-3_size-128-4                908814              1288 ns/op
BenchmarkLRU_Concurrent/str_buckets-3_af-4_wr-3_size-128-4               1222749              1003 ns/op
BenchmarkLRU_Concurrent/str_buckets-4_af-4_wr-3_size-128-4               1047278              1149 ns/op
BenchmarkLRU_Concurrent/str_buckets-1_af-4_wr-4_size-128-4                600139              2110 ns/op
BenchmarkLRU_Concurrent/str_buckets-2_af-4_wr-4_size-128-4                726241              1824 ns/op
BenchmarkLRU_Concurrent/str_buckets-3_af-4_wr-4_size-128-4                885265              1292 ns/op
BenchmarkLRU_Concurrent/str_buckets-4_af-4_wr-4_size-128-4                694820              1509 ns/op
PASS
ok      github.com/mattermost/mattermost-server/v5/services/cache       52.335s
```

Successive runs give about the same results, with remarkable values:

 * LRU with 2 cache writing routines (WR) or more is super slow.
 * Striped LRU with only 1 bucket is slower than everything because of the hashing and struct overhead
 * Striped LRU with 2 cache WR or more and at least 2 buckets is always faster than LRU with 2 WR
 * Having as much WR as CPU cores leaves no room for the reading thread, which is my guess for the slower "4 bucket 4 wr" -> slowest of all results (except 1 bucket -> multiple writers)
 * It seems that the most optimized configuration is to have `Buckets = NumCPU - 1` no matter the number of writers, considering 1 reading thread